### PR TITLE
Remove implicit usage of AWS JSONObject/JSONArray.

### DIFF
--- a/infer-plugin/src/test/groovy/com/uber/infer/util/InferAndroidPluginAppIntegrationTest.groovy
+++ b/infer-plugin/src/test/groovy/com/uber/infer/util/InferAndroidPluginAppIntegrationTest.groovy
@@ -77,16 +77,15 @@ class InferAndroidPluginAppIntegrationTest extends IntegrationTest {
 
                     repositories {
                         mavenLocal()
-                        maven { url 'http://artifactory.uber.internal:4587/artifactory/mobile' }
+                        jcenter()
                     }
 
                     dependencies {
-                        apt 'com.ubercab:rave-compiler:0.4.0'
+                        apt 'com.uber:rave-compiler:0.6.0'
 
                         compile 'com.android.support:support-annotations:23.0.1'
                         compile 'com.intellij:annotations:5.1'
-                        compile 'com.ubercab:rave:0.4.0'
-
+                        compile 'com.uber:rave:0.6.0'
 
                         // Annotations included to test provided support.
                         provided 'javax.annotation:jsr250-api:1.0'

--- a/infer-plugin/src/test/groovy/com/uber/infer/util/InferAndroidPluginLibraryIntegrationTest.groovy
+++ b/infer-plugin/src/test/groovy/com/uber/infer/util/InferAndroidPluginLibraryIntegrationTest.groovy
@@ -43,15 +43,15 @@ class InferAndroidPluginLibraryIntegrationTest extends IntegrationTest {
 
                     repositories {
                         mavenLocal()
-                        maven { url 'http://artifactory.uber.internal:4587/artifactory/mobile' }
+                        jcenter()
                     }
 
                     dependencies {
-                        apt 'com.ubercab:rave-compiler:0.4.0'
+                        apt 'com.uber:rave-compiler:0.6.0'
 
                         compile 'com.android.support:support-annotations:23.0.1'
                         compile 'com.intellij:annotations:5.1'
-                        compile 'com.ubercab:rave:0.4.0'
+                        compile 'com.uber:rave:0.6.0'
 
                         // Annotations included to test provided support.
                         provided 'javax.annotation:jsr250-api:1.0'


### PR DESCRIPTION
This is very strange - these AWS classes are nowhere in the dependency tree, but somehow IntellIj automatically imports them (even on a separate machine) and the plug-in works.

TODO:
* [ ] Test against project in https://github.com/uber-common/infer-plugin/issues/12