### PR TITLE
Add support for more provided/apt configurations

### DIFF
--- a/infer-plugin/src/main/groovy/com/uber/infer/InferAndroidPlugin.groovy
+++ b/infer-plugin/src/main/groovy/com/uber/infer/InferAndroidPlugin.groovy
@@ -7,6 +7,7 @@ import com.uber.infer.task.PrepareForInfer
 import com.uber.infer.task.CheckForInfer
 import com.uber.infer.task.Eradicate
 import com.uber.infer.task.Infer
+import com.uber.infer.util.ConfigurationUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -91,7 +92,7 @@ class InferAndroidPlugin implements Plugin<Project> {
             }
 
             processorDependencies = {
-                project.configurations.getByName("apt")
+                ConfigurationUtils.getAvailable(project, 'apt', 'annotationProcessor')
             }
             providedDependencies = {
                 project.configurations.getByName("provided") +

--- a/infer-plugin/src/main/groovy/com/uber/infer/InferJavaPlugin.groovy
+++ b/infer-plugin/src/main/groovy/com/uber/infer/InferJavaPlugin.groovy
@@ -1,15 +1,10 @@
 package com.uber.infer
 
 import com.uber.infer.extension.InferPluginExtension
-import com.uber.infer.task.DeleteInferConfig
-import com.uber.infer.task.PrepareForInfer
-import com.uber.infer.task.CheckForInfer
-
-import com.uber.infer.task.Eradicate
-import com.uber.infer.task.Infer
+import com.uber.infer.task.*
+import com.uber.infer.util.ConfigurationUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
 /**
  * Infer plug-in for standard Java projects.
  */
@@ -26,10 +21,10 @@ class InferJavaPlugin implements Plugin<Project> {
                 project.configurations.getByName("compile")
             }
             processorDependencies = {
-                project.configurations.getByName("apt")
+                ConfigurationUtils.getAvailable(project, 'apt')
             }
             providedDependencies = {
-                project.configurations.getByName("provided")
+                ConfigurationUtils.getAvailable(project, 'provided', 'compileOnly')
             }
             sourceFiles = {
                 project.sourceSets.main.java

--- a/infer-plugin/src/main/groovy/com/uber/infer/util/ConfigurationUtils.groovy
+++ b/infer-plugin/src/main/groovy/com/uber/infer/util/ConfigurationUtils.groovy
@@ -1,0 +1,20 @@
+package com.uber.infer.util
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.UnknownConfigurationException
+import org.gradle.api.file.FileCollection
+
+class ConfigurationUtils {
+
+  private ConfigurationUtils() {}
+
+  static FileCollection getAvailable(Project project, String... configurations) {
+    def available = [] as Set
+    configurations.each { String configuration ->
+      try {
+        available += project.configurations.getByName(configuration).files
+      } catch (UnknownConfigurationException ignored) { }
+    }
+    return project.files(available)
+  }
+}

--- a/infer-plugin/src/test/groovy/com/uber/infer/util/InferJavaPluginIntegrationTest.groovy
+++ b/infer-plugin/src/test/groovy/com/uber/infer/util/InferJavaPluginIntegrationTest.groovy
@@ -2,10 +2,23 @@ package com.uber.infer.util
 
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
+@RunWith(Parameterized)
 class InferJavaPluginIntegrationTest extends IntegrationTest {
 
     private String javaTestBuildFile
+    private String providedConfiguration
+
+    @Parameterized.Parameters static Collection<Object[]> data() {
+        def data = ['provided', 'compileOnly']
+        return data.collect { [it] as Object[] }
+    }
+
+    InferJavaPluginIntegrationTest(String providedConfiguration) {
+        this.providedConfiguration = providedConfiguration
+    }
 
     @Before
     void setup() {
@@ -32,7 +45,7 @@ class InferJavaPluginIntegrationTest extends IntegrationTest {
 
                 dependencies {
                     // Annotations included to test provided support.
-                    provided 'javax.annotation:jsr250-api:1.0'
+                    ${providedConfiguration} 'javax.annotation:jsr250-api:1.0'
 
                     compile 'com.intellij:annotations:5.1'
                 }

--- a/infer-plugin/src/test/groovy/com/uber/infer/util/IntegrationTest.groovy
+++ b/infer-plugin/src/test/groovy/com/uber/infer/util/IntegrationTest.groovy
@@ -8,7 +8,7 @@ import org.junit.rules.TemporaryFolder
 
 class IntegrationTest {
 
-    static String VERSION_GRADLE = "2.10"
+    static String VERSION_GRADLE = "2.13"
 
     @Rule
     public TemporaryFolder mFolder = new TemporaryFolder()


### PR DESCRIPTION
- Adds support for the `compileOnly` configuration for java projects introduced in Gradle 2.12+
- Adds support for the `annotationProcessor` configuration for android projects using Jack