### PR TITLE
Enable plugin to run on JRE 7

### DIFF
--- a/infer-plugin/build.gradle
+++ b/infer-plugin/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'groovy'
 
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
 repositories {
     jcenter()
 }


### PR DESCRIPTION
Fixes #13.

When #15 lands, this will be verified by Travis automatically using `oraclejdk7`.