### PR TITLE
Bump gradle-2.13 to 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ allprojects {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:2.1.0'
+                classpath 'com.android.tools.build:gradle:2.2.2'
             }
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip

--- a/infer-plugin/build.gradle
+++ b/infer-plugin/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile 'com.android.tools.build:gradle:2.1.0'
 
     testCompile gradleTestKit()
+    testCompile 'junit:junit:4.12'
 }
 
 // https://docs.gradle.org/current/userguide/test_kit.html

--- a/infer-plugin/src/main/groovy/com/uber/infer/InferAndroidPlugin.groovy
+++ b/infer-plugin/src/main/groovy/com/uber/infer/InferAndroidPlugin.groovy
@@ -83,11 +83,12 @@ class InferAndroidPlugin implements Plugin<Project> {
             }
             compileDependencies = {
                 project.files(project.fileTree(dir: "${project.buildDir.path}/intermediates/exploded-aar",
-                        include: "**/*.jar")).plus(
+                        include: "**/*.jar")).plus(project.files(
                         project.configurations.asList().findAll {
                             String configName = it.name.toLowerCase()
                             configName.contains("compile") && !configName.contains("test")
-                        } as Iterable<File>
+                            it.asFileTree
+                        })
                 )
             }
 


### PR DESCRIPTION
- Fix `Gradle version 2.10 is required. Current version is 3.1`: Bump `com.android.tools.build:gradle:2.1.0` to `2.2.2`
- Add test compile dependency. Fix compile error: `RunCommandUtilsTest.groovy: 3: unable to resolve class org.junit.Test`
- Fix `No signature of method: static com.uber.infer.util.JavacUtils.generateJavacArgument() is applicable for argument types: (java.util.ArrayList, java.lang.String)`