### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.scripts/prepare-container-with-infer.sh
+++ b/.scripts/prepare-container-with-infer.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+wget -O Dockerfile https://raw.githubusercontent.com/facebook/infer/master/docker/Dockerfile
+
+if ! docker --version > /dev/null; then
+  echo "docker is not installed."
+  exit 1
+fi
+
+if [ ! -f Dockerfile ]; then
+  echo "Dockerfile not found."
+  exit 1
+fi
+
+export INFER_IMAGE_NAME="infer"
+docker build -t $INFER_IMAGE_NAME .

--- a/.scripts/travis.linux.before_install.sh
+++ b/.scripts/travis.linux.before_install.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Check dokumentation for more info about Infer installation on Linux
+# https://github.com/facebook/infer/blob/master/INSTALL.md#pre-compiled-versions
+
+# opam >= 1.2.0
+# Python 2.7 <-- preinstalled in Travis
+# pkg-config
+# libffi >= 3.0
+# Java (only needed for the Java analysis) <-- preinstalled in Travis
+# gcc >= 4.7.2 or clang >= 3.1 (only needed for the C/Objective-C analysis) <-- preinstalled in Travis
+# autoconf >= 2.63 and automake >= 1.11.1 (if building from git)
+
+echo -e "\e[33mInstalling Infer dependencies\e[0m"
+sudo apt-get update
+sudo apt-get -o Dpkg::Options::="--force-confnew" upgrade -y
+sudo apt-get -o Dpkg::Options::="--force-confnew" install -y  \
+  autoconf \
+  automake \
+  build-essential \
+  libffi-dev \
+  libgmp-dev \
+  libmpc-dev \
+  libmpfr-dev \
+  m4 \
+  pkg-config \
+  python-software-properties \
+  unzip \
+  zlib1g-dev
+
+# Opam is broken on some Ubuntu versions
+# Install Opam from official repository (http://opam.ocaml.org/doc/Install.html#Binarydistribution)
+echo -e "\e[33mInstalling Opam\e[0m"
+yes '' | sudo add-apt-repository ppa:avsm/ppa
+sudo apt-get update
+sudo apt-get install -y ocaml ocaml-native-compilers camlp4-extra opam
+
+# Checkout Infer
+echo -e "\e[33mCloning Infer from Github\e[0m"
+git clone https://github.com/facebook/infer.git infer-sources
+cd infer-sources
+# Compile Infer
+echo -e "\e[33mCompiling Infer\e[0m"
+./build-infer.sh java
+# Install Infer into your PATH
+echo -e "\e[33mAdding Infer to PATH\e[0m"
+export PATH=`pwd`/infer/bin:$PATH

--- a/.scripts/travis.osx.base.before_install.sh
+++ b/.scripts/travis.osx.base.before_install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+brew update
+brew install android-sdk
+eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-android-m2repository || true
+eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-google-m2repository || true
+eval echo \"y\" | android update sdk --no-ui --force --all --filter build-tools-23.0.2 || true
+eval echo \"y\" | android update sdk --no-ui --force --all --filter build-tools-23.0.3 || true
+eval echo \"y\" | android update sdk --no-ui --force --all --filter android-15 || true
+eval echo \"y\" | android update sdk --no-ui --force --all --filter android-23 || true
+export ANDROID_HOME=/usr/local/opt/android-sdk
+brew install infer

--- a/.scripts/travis.osx.jdk7.before_install.sh
+++ b/.scripts/travis.osx.jdk7.before_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# upgrade brew cask
+brew update && brew upgrade caskroom/cask/brew-cask && brew cleanup && brew cask cleanup
+# remove existing Java
+sudo rm -rf /Library/Java/JavaVirtualMachines
+# install Java 7
+brew cask install caskroom/versions/java7
+javac -version
+# install Android and Infer
+source .scripts/travis.osx.base.before_install.sh

--- a/.travis-infer-docker.yml
+++ b/.travis-infer-docker.yml
@@ -1,0 +1,41 @@
+# Disabling sudo moves build to the Container Based Infrastructure on Travis CI
+
+language: android
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: trusty
+      group: legacy
+      services:
+        - docker
+      jdk: oraclejdk8
+      before_install:
+        - source .scripts/prepare-container-with-infer.sh
+        # run container with installed Infer
+        - docker run -itd $INFER_IMAGE_NAME
+        # copy build folder ("infer-plugin") to container
+        - docker cp $TRAVIS_BUILD_DIR $(docker ps -q):/
+
+before_install:
+  # Prepare Android licenses (required to install Anroid dependencies)
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+
+script:
+  # install Android dependencies and run checks in one command inside docker container
+  # if we separate this into separate `docker exec` commands, than Android SDK dependencies will not be saved
+  # Android SDK folder should be copied as well, as Docker uses AUFS by default
+  # which doesn't support all operations required by sdk manager
+  # see https://github.com/travis-ci/travis-ci/issues/2848#issuecomment-58780257
+  - docker exec -it $(docker ps -q) /bin/bash -c 'export ANDROID_HOME=${TRAVIS_BUILD_DIR}/android-sdk; export PATH=${ANDROID_HOME}/:${ANDROID_HOME}/tools/:${ANDROID_HOME}/platform-tools/:${PATH}; cp -R /opt/android-sdk-linux ${TRAVIS_BUILD_DIR}/android-sdk; eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-android-m2repository; eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-google-m2repository; eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-android-support; eval echo \"y\" | android update sdk --no-ui --force --all --filter extra-google-google_play_services; eval echo \"y\" | android update sdk --no-ui --force --all --filter tools; eval echo \"y\" | android update sdk --no-ui --force --all --filter platform-tools; eval echo \"y\" | android update sdk --no-ui --force --all --filter android-23; eval echo \"y\" | android update sdk --no-ui --force --all --filter build-tools-23.0.2; cd /infer-plugin; ./gradlew build --stacktrace; exit $?'
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle
+    - $HOME/.android
+    - ${TRAVIS_BUILD_DIR}/gradle/caches/
+    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: android
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      jdk: oraclejdk8
+      env:
+        - DISABLED_CONFIG=true
+      android:
+        components:
+          - platform-tools
+          - tools
+          - build-tools-23.0.2
+          - android-23
+      before_install:
+        # currently, infer-plugin tests fail on Linux
+        # more info at https://github.com/uber-common/infer-plugin/issues/31
+        - "echo \"DISABLED CONFIGURATION\"; exit 0"
+        # compile and install Infer from sources
+        - source .scripts/travis.linux.before_install.sh
+        # use travis-infer-docker.yml for Infer with Docker installation
+    - os: osx
+      osx_image: xcode8
+      env:
+        - DISABLED_CONFIG=true
+      before_install:
+        # infer-plugin isn't compatible with JDK-7, adjustments needed
+        - "echo \"DISABLED CONFIGURATION\"; exit 0"
+        # jdk7
+        - source .scripts/travis.osx.jdk7.before_install.sh
+    - os: osx
+      # jdk8
+      osx_image: xcode8
+      env:
+        - WORKING_CONFIG=true
+      before_install:
+        - source .scripts/travis.osx.base.before_install.sh
+
+script:
+  # navigate back to the project folder (Infer installation process changes dir)
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd $TRAVIS_BUILD_DIR ; fi
+  - which infer
+  - infer --version
+  - ./gradlew build --stacktrace
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle
+    - $HOME/.android
+    - ${TRAVIS_BUILD_DIR}/gradle/caches/
+    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Infer Gradle Plugin
 
+[![Build Status](https://travis-ci.org/uber-common/infer-plugin.svg?branch=master)](https://travis-ci.org/uber-common/infer-plugin)
+
 This Gradle plug-in creates tasks to run [Infer](http://fbinfer.com) on Android and Java projects.
 
 ## Integration

--- a/infer-plugin/build.gradle
+++ b/infer-plugin/build.gradle
@@ -31,6 +31,13 @@ task createClasspathManifest {
     }
 }
 
+tasks.withType(Test) {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat = "full"
+    }
+}
+
 // Add the classpath file to the test runtime classpath
 dependencies {
     testRuntime files(createClasspathManifest)

--- a/infer-sample/app/build.gradle
+++ b/infer-sample/app/build.gradle
@@ -6,18 +6,18 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:22.2.0'
+    compile 'com.android.support:support-annotations:25.1.0'
     compile 'com.jakewharton:butterknife:7.0.1'
 }
 
 android {
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
     compileSdkVersion 23
 
     defaultConfig {
         applicationId "com.uber.inferplugin"
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 23
 
         buildConfigField "String", "APP_NAME", "\"inferplugin\""
     }
@@ -27,6 +27,11 @@ android {
         exclude 'LICENSE.txt'
         exclude 'LICENSE'
         exclude 'NOTICE'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
     }
 
     signingConfigs {

--- a/infer-sample/app/config/lint/lint.xml
+++ b/infer-sample/app/config/lint/lint.xml
@@ -6,5 +6,5 @@
     <issue id="InvalidPackage">
         <ignore path="*okio*.jar"/>
     </issue>
-</lint>
 
+</lint>

--- a/infer-sample/app/src/main/res/menu/menu_main.xml
+++ b/infer-sample/app/src/main/res/menu/menu_main.xml
@@ -1,8 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".MainActivity">
-    <item
-        android:id="@+id/action_settings"
-        android:orderInCategory="100"
-        android:title="@string/action_settings"/>
-</menu>

--- a/infer-sample/app/src/main/res/values/strings.xml
+++ b/infer-sample/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">Android InferPlugin</string>
-    <string name="action_settings">Settings</string>
 </resources>


### PR DESCRIPTION
Adds integration with Travis CI (previous attempt was in #15).

What's done:
- project compiles fine and tests pass on Mac OS (JDK 8) build machine

What's partially done:
- project compiles fine and tests partially pass on Linux (Ubuntu, JDK 8). Related issue https://github.com/uber-common/infer-plugin/issues/31 was created.

What doesn't work:
- project doesn't compile on build machine with JDK 7. In case someone is curious enough and has time to work on this - please check builds configuration in `.travis.yml` file marked with `DISABLED_CONFIG=true` in `env` section (linux JDK 7, osx JDK 7).

Notes about integration:
- `Infer` dependency is installed on Mac OS using `brew`. Works just perfect.
- `Infer` dependency is installed via Docker on linux (check `.travis-infer-docker.yml` file) or compiled from sources (check `.scripts/travis.linux.before_install.sh`).
- Travis provides every build machine with pre-installed Oracle JDK 8. In case we need JDK 7, we remove installed JDK 8 from build machine and install JDK 7 (check `.scripts/travis.osx.jdk7.before_install.sh`).

Please consider https://travis-ci.org/vgaidarji/infer-plugin/builds/196540994 build as an example of working integration. IMO, there're at least 4 cases to check (linux JDK 7 & 8, osx JDK 7 & 8), and **only osx JDK 8** works for now, which is not good, but bearable.

@tonycosentini Please review. In case you decide that everything is fine, we can remove `linux JDK 7 & 8` and `osx JDK 8` not working configurations at all to clean up the repository. Or someone will pick it up and fix it (but in separate PR).